### PR TITLE
Swift 4 refactoring - syntactical changes and new JSONDecoder()

### DIFF
--- a/Networking.playground/Contents.swift
+++ b/Networking.playground/Contents.swift
@@ -5,12 +5,12 @@
 //: It will serve up the current directory, so make sure to be in the directory containing episodes.json
 
 import UIKit
-import XCPlayground
+import PlaygroundSupport
 
 
 typealias JSONDictionary = [String: AnyObject]
 
-let url = NSURL(string: "http://localhost:8000/episodes.json")!
+let url = URL(string: "http://localhost:8000/episodes.json")!
 
 
 struct Episode {
@@ -21,7 +21,7 @@ struct Episode {
 extension Episode {
     init?(dictionary: JSONDictionary) {
         guard let id = dictionary["id"] as? String,
-            title = dictionary["title"] as? String else { return nil }
+            let title = dictionary["title"] as? String else { return nil }
         self.id = id
         self.title = title
     }
@@ -32,15 +32,15 @@ struct Media {}
 
 
 struct Resource<A> {
-    let url: NSURL
-    let parse: NSData -> A?
+    let url: URL
+    let parse: (Data) -> A?
 }
 
 extension Resource {
-    init(url: NSURL, parseJSON: AnyObject -> A?) {
+    init(url: URL, parseJSON: @escaping (Any) -> A?) {
         self.url = url
         self.parse = { data in
-            let json = try? NSJSONSerialization.JSONObjectWithData(data, options: [])
+            let json = try? JSONSerialization.jsonObject(with: data, options: [])
             return json.flatMap(parseJSON)
         }
     }
@@ -50,14 +50,14 @@ extension Resource {
 extension Episode {
     static let all = Resource<[Episode]>(url: url, parseJSON: { json in
         guard let dictionaries = json as? [JSONDictionary] else { return nil }
-        return dictionaries.flatMap(Episode.init)
+        return dictionaries.compactMap(Episode.init)
     })
 }
 
 
 final class Webservice {
-    func load<A>(resource: Resource<A>, completion: (A?) -> ()) {
-        NSURLSession.sharedSession().dataTaskWithURL(resource.url) { data, _, _ in
+    func load<A>(resource: Resource<A>, completion: @escaping (A?) -> ()) {
+        URLSession.shared.dataTask(with: resource.url) { data, _, _ in
             guard let data = data else {
                 completion(nil)
                 return
@@ -68,8 +68,8 @@ final class Webservice {
 }
 
 
-XCPlaygroundPage.currentPage.needsIndefiniteExecution = true
+PlaygroundPage.current.needsIndefiniteExecution = true
 
-Webservice().load(Episode.all) { result in
-    print(result)
+Webservice().load(resource: Episode.all) { result in
+    print(result ?? "")
 }

--- a/README.md
+++ b/README.md
@@ -2,3 +2,9 @@
 ## Networking
 
 This is the code that accompanies Swift Talk Episode 1: [Networking](https://talk.objc.io/episodes/S01E01-networking)
+
+It has been slightly adapted to work with Xcode 9 / Swift 4.
+
+* some syntactical and type changes
+* use of new JSONDecoder(), which simplifies code lot - see [Apple documentation](https://developer.apple.com/documentation/foundation/jsondecoder)
+


### PR DESCRIPTION
There seem to be some pull requests for Swift 4 compatibility - this one also simplifies the code by making use of JSONDecoder().